### PR TITLE
Add build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "build": "tsc"
   },
   "keywords": [],
   "author": "Dirk Riehle",


### PR DESCRIPTION
Allows users to build with `npm run build` (similar to `npm run test`).
This way developers don't have to remember the proper build command.