### PR TITLE
Init GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Automated Public Tests
+on:
+  push:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
@@ -20,6 +20,41 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run public tests
-        run: npm run test
-        if: github.repository != 'riehlegroup/adap-names'
+  test:
+    if: github.repository != 'riehlegroup/adap-names'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run tests for exercise B01
+        run: npm run test:b01
+        if: ${{ !cancelled() }}
+
+      - name: Run tests for exercise B02
+        run: npm run test:b02
+        if: ${{ !cancelled() }}
+
+      - name: Run tests for exercise B03
+        run: npm run test:b03
+        if: ${{ !cancelled() }}
+
+      - name: Run tests for exercise B04
+        run: npm run test:b04
+        if: ${{ !cancelled() }}
+
+      - name: Run tests for exercise B05
+        run: npm run test:b05
+        if: ${{ !cancelled() }}
+
+      - name: Run tests for exercise B06
+        run: npm run test:b06
+        if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
+      - name: Run public tests
         run: npm run test
+        if: github.repository != 'riehlegroup/adap-names'

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "build": "tsc",
     "test": "vitest",
-    "build": "tsc"
+    "test:b01": "vitest --dir test/adap-b01*",
+    "test:b02": "vitest --dir test/adap-b02*",
+    "test:b03": "vitest --dir test/adap-b03*",
+    "test:b04": "vitest --dir test/adap-b04*",
+    "test:b05": "vitest --dir test/adap-b05*",
+    "test:b06": "vitest --dir test/adap-b06*"
   },
   "keywords": [],
   "author": "Dirk Riehle",


### PR DESCRIPTION
This PR introduces a basic setup of GitHub Actions.

Tests are skipped on the main repo (`riehlegroup/adap-names`) since we expect them to fail.

Depends on #1.