### PR TITLE
Fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "adap-names-solutions",
+  "name": "adap-names",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "adap-names-solutions",
+      "name": "adap-names",
       "version": "1.0.0",
       "dependencies": {
         "vitest": "^2.0.5"


### PR DESCRIPTION
The `package-lock.json` was not updated after changing the package name to `adap-names`. This was done by running `npm install`.