### PR TITLE
Use function decorators for methodtype annotation

### DIFF
--- a/src/adap-b01/coordinates/Coordinate.ts
+++ b/src/adap-b01/coordinates/Coordinate.ts
@@ -1,3 +1,10 @@
+function methodtype(type: string) {
+    return function(target: any) {
+        target.methodtype = type;
+        return target;
+    }
+}
+
 export class Coordinate {
 
     private x: number = 0;
@@ -60,7 +67,7 @@ export class Coordinate {
         this.initialize(0, 0);
     }
 
-    /** @methodtype get-method */
+    @methodtype("get-method")
     public getX(): number {
         return this.x;
     }

--- a/test/adap-b01/coordinates/Coordinate.test.ts
+++ b/test/adap-b01/coordinates/Coordinate.test.ts
@@ -11,6 +11,17 @@ describe('Basic Coordinate function tests', () => {
   });
 });
 
+describe("Method types", () => {
+  it("Decorators", () => {
+    let c: Coordinate = new Coordinate();
+    interface typedMethod {
+      (): any;
+      methodtype: string;
+    };
+    expect((c.getX as typedMethod).methodtype).toBe("get-method");
+  })
+});
+
 function round(v: number): number {
   return Math.round(10000 * v) / 10000;
 }


### PR DESCRIPTION
See title. Type annotations (yes, i know the naming is confusing here with **method**type annotations, but the former is the official term in TS) were basically thrown out of the window to keep the signatures relatively simple. Types aren't enforced in TS anyway...

Using decorators instead of comments allows testing for methodtype annotations within vitest, so no hacking around with babel or jsdoc necessary!

Preferably, the decorator should be moved somewhere where it can be imported if needed, though such a common module does not exist for adap-names (yet).