### PR TITLE
Improve test commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest",
-    "test:b01": "vitest --dir test/adap-b01*",
-    "test:b02": "vitest --dir test/adap-b02*",
-    "test:b03": "vitest --dir test/adap-b03*",
-    "test:b04": "vitest --dir test/adap-b04* --passWithNoTests",
-    "test:b05": "vitest --dir test/adap-b05* --passWithNoTests",
-    "test:b06": "vitest --dir test/adap-b06* --passWithNoTests"
+    "test:b01": "vitest --dir test/adap-b01 --passWithNoTests",
+    "test:b02": "vitest --dir test/adap-b02 --passWithNoTests",
+    "test:b03": "vitest --dir test/adap-b03 --passWithNoTests",
+    "test:b04": "vitest --dir test/adap-b04 --passWithNoTests",
+    "test:b05": "vitest --dir test/adap-b05 --passWithNoTests",
+    "test:b06": "vitest --dir test/adap-b06 --passWithNoTests"
   },
   "keywords": [],
   "author": "Dirk Riehle",


### PR DESCRIPTION
- Removes the star from the test commands to improve Windows compatibility.
- Adds `--passWithNoTests` to every script to future-proof the setup